### PR TITLE
Fix case-sensitive docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
     Rocket Avionics Flight Subsystem for OSU HART
     <br />
     <!-- LINK TO DOCUMENTATION -->
-    <a href="https://hart-avionics.github.io/osu-hart-commercial-avionics/"><strong>Explore the docs »</strong></a>
+    <a href="https://hart-avionics.github.io/OSU-HART-Commercial-Avionics/"><strong>Explore the docs »</strong></a>
     <br />
     <br />
     <!-- LINK TO DEMO


### PR DESCRIPTION
Description
------------
Apparently the `https://hart-avionics.github.io/osu-hart-commercial-avionics/` link gives a 404 error and needs to be `https://hart-avionics.github.io/OSU-HART-Commercial-Avionics/` instead.

### Type of change
- Bug fix (non-breaking change which fixes an issue)

How Has This Been Tested?
--------------------------
Changing the letter case of the URL caused 404's. Once the link was changed, clicking on it opened up the correct page.

Checklist:
-----------
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
    - No current tests, but a [link checker][link-checker-issue] could test this.
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
    - Other repositories may include case-insensitive links still. The [link checker][link-checker-issue] would be able to catch these broken links.

<!-- Links -->
[link-checker-issue]: https://github.com/HART-Avionics/docs/issues/10 "Link Checker Issue"